### PR TITLE
chore: update PUBLIC_{KEY,CERT}_FILE references to {KEY,CERT}_FILE 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ package:
   deploy:
     set:
       domain: bigbang.dev
-      public_key_file: bigbang.dev.key
-      public_cert_file: bigbang.dev.cert
+      key_file: bigbang.dev.key
+      cert_file: bigbang.dev.cert
       name: "${DUBBD_ENV}-big-bang-cluster"
 EOF
 

--- a/aws/zarf-config.yaml
+++ b/aws/zarf-config.yaml
@@ -11,8 +11,8 @@ package:
   deploy:
     set:
       domain: bigbang.dev
-      public_key_file: bigbang.dev.key
-      public_cert_file: bigbang.dev.cert
+      key_file: bigbang.dev.key
+      cert_file: bigbang.dev.cert
       name: "big-bang-aws" # maybe inject something here for the GH PR?
       state_bucket_name: uds-dev-state-bucket
       state_key: tfstate/dev/uds-dev-state-bucket.tfstate

--- a/defense-unicorns-distro/scripts/cat_cert.sh
+++ b/defense-unicorns-distro/scripts/cat_cert.sh
@@ -1,1 +1,1 @@
-awk '{printf "%s\\n", $0}' ###ZARF_VAR_PUBLIC_CERT_FILE### | sed "s/\"/\\\\\"/g"
+awk '{printf "%s\\n", $0}' ###ZARF_VAR_CERT_FILE### | sed "s/\"/\\\\\"/g"

--- a/defense-unicorns-distro/scripts/cat_key.sh
+++ b/defense-unicorns-distro/scripts/cat_key.sh
@@ -1,1 +1,1 @@
-awk '{printf "%s\\n", $0}' ###ZARF_VAR_PUBLIC_KEY_FILE### | sed "s/\"/\\\\\"/g"
+awk '{printf "%s\\n", $0}' ###ZARF_VAR_KEY_FILE### | sed "s/\"/\\\\\"/g"

--- a/defense-unicorns-distro/zarf-config.yaml
+++ b/defense-unicorns-distro/zarf-config.yaml
@@ -9,5 +9,5 @@ package:
   deploy:
     set:
       domain: bigbang.dev
-      public_key_file: bigbang.dev.key
-      public_cert_file: bigbang.dev.cert
+      key_file: bigbang.dev.key
+      cert_file: bigbang.dev.cert

--- a/defense-unicorns-distro/zarf.yaml
+++ b/defense-unicorns-distro/zarf.yaml
@@ -16,21 +16,13 @@ variables:
 - name: DOMAIN
   default: bigbang.dev
   prompt: false
-- name: PUBLIC_CERT_FILE
+- name: CERT_FILE
   default: bigbang.dev.cert
-  description: "This file contains the cert for the public ingress gateway"
+  description: "This file contains the cert for the ingress gateways"
   prompt: false
-- name: PUBLIC_KEY_FILE
+- name: KEY_FILE
   default: bigbang.dev.key
-  description: "This file contains the key for the public ingress gateway"
-  prompt: false
-- name: ADMIN_CERT_FILE
-  default: bigbang.dev.cert
-  description: "This file contains the cert for the admin ingress gateway"
-  prompt: false
-- name: ADMIN_KEY_FILE
-  default: bigbang.dev.key
-  description: "This file contains the key for the admin ingress gateway"
+  description: "This file contains the key for the ingress gateways"
   prompt: false
 - name: APPROVED_REGISTRIES
   description: "Regex of approved registries to allow in cluster"

--- a/k3d/zarf-config.yaml
+++ b/k3d/zarf-config.yaml
@@ -9,6 +9,6 @@ package:
   deploy:
     set:
       domain: bigbang.dev
-      public_key_file: bigbang.dev.key
-      public_cert_file: bigbang.dev.cert
+      key_file: bigbang.dev.key
+      cert_file: bigbang.dev.cert
       host_path: "/var/lib/rancher/k3s/storage/*"


### PR DESCRIPTION
Moving forward both the admin and tenant ingressGateways will use the same cert.