### PR TITLE
fix: set min tls version at gateway

### DIFF
--- a/values/istio.yaml
+++ b/values/istio.yaml
@@ -7,6 +7,31 @@ istio:
     tenant-ingressgateway:
       type: "LoadBalancer"
   values:
+    gateways:
+      admin:
+        servers:
+          - hosts:
+              - "*.{{ .Values.domain }}"
+            port:
+              name: https
+              number: 8443
+              protocol: HTTPS
+            tls:
+              credentialName: "admin-cert"
+              mode: "SIMPLE"
+              minProtocolVersion: "TLSV1_3"
+      tenant:
+        servers:
+          - hosts:
+              - "*.{{ .Values.domain }}"
+            port:
+              name: https
+              number: 8443
+              protocol: HTTPS
+            tls:
+              credentialName: "tenant-cert"
+              mode: "SIMPLE"
+              minProtocolVersion: "TLSV1_3"
     meshConfig:
       meshMTLS:
         minProtocolVersion: TLSV1_3


### PR DESCRIPTION
Adds minimum TLS at the gateway in addition to the mesh config.

See https://repo1.dso.mil/big-bang/product/packages/istio-controlplane/-/issues/78#note_738607

Related to https://github.com/defenseunicorns/zarf-package-big-bang/issues/220