### PR TITLE
Delete both S3 and KMS when force_delete is set to true

### DIFF
--- a/aws/loki/output.tf
+++ b/aws/loki/output.tf
@@ -24,3 +24,7 @@ output "kms_key_arn" {
   description = "The ARN of the OIDC Provider of the EKS Cluster"
   value       = local.kms_key_arn
 }
+
+output "force_destroy" {
+  value = var.force_destroy
+}

--- a/aws/zarf.yaml
+++ b/aws/zarf.yaml
@@ -100,7 +100,8 @@ components:
             dir: run/loki
       onRemove:
         before:
-          - cmd: "terraform destroy -auto-approve"
+          - cmd: |
+              if [ "$(terraform output force_destroy)" = true ]; then terraform destroy -auto-approve; fi
             dir: run/loki
   - name: outputs
     required: true

--- a/aws/zarf.yaml
+++ b/aws/zarf.yaml
@@ -101,7 +101,7 @@ components:
       onRemove:
         before:
           - cmd: |
-              if [ "$(terraform output force_destroy)" = true ]; then terraform destroy -auto-approve; fi
+              if [ -d "run/loki" ] && [ "$(terraform output force_destroy)" = true ]; then terraform destroy -auto-approve; fi
             dir: run/loki
   - name: outputs
     required: true

--- a/aws/zarf.yaml
+++ b/aws/zarf.yaml
@@ -101,8 +101,16 @@ components:
       onRemove:
         before:
           - cmd: |
-              if [ -d "run/loki" ] && [ "$(terraform output force_destroy)" = true ]; then terraform destroy -auto-approve; fi
-            dir: run/loki
+              if [ -d "run/loki" ]; then
+                cd run/loki
+                if [ "$(terraform output force_destroy)" = true ]; then
+                  terraform destroy -auto-approve
+                else
+                  echo "Skipping remove, force_destroy is set to false"
+                fi
+              else
+                echo "Cannot remove: run/loki directory does not exist"
+              fi
   - name: outputs
     required: true
     actions:


### PR DESCRIPTION
Attempt at resolving #244 

~~2 paths tested:~~
~~- When force_destroy is set to 'true' both S3 bucket and KMS key are deleted~~
~~- When force_destroy is set to 'false" only the S3 bucket is deleted~~