### PR TITLE
fix: Add AWS LB annotations

### DIFF
--- a/aws/values/aws-istio.yaml
+++ b/aws/values/aws-istio.yaml
@@ -1,0 +1,12 @@
+istio:
+  ingressGateways:
+    admin-ingressgateway:
+      kubernetesResourceSpec:
+        serviceAnnotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    tenant-ingressgateway:
+      kubernetesResourceSpec:
+        serviceAnnotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"

--- a/aws/zarf.yaml
+++ b/aws/zarf.yaml
@@ -139,4 +139,5 @@ components:
       bigbang:
         version: "###ZARF_PKG_TMPL_BIGBANG_VERSION###"
         valuesFiles:
+        - values/aws-istio.yaml
         - values/aws-loki.yaml


### PR DESCRIPTION
Fixes missing annotations. Added only to dubbd-aws since these would not be applicable for k3d, etc.