### PR TITLE
Switch istio to TID by default

### DIFF
--- a/values/istio.yaml
+++ b/values/istio.yaml
@@ -1,5 +1,6 @@
 istio:
   enabled: true
+  enterprise: true
   ingressGateways:
     admin-ingressgateway:
       type: "LoadBalancer"


### PR DESCRIPTION
Switches istio "enterprise" mode on by default (Tetrate Istio Distribution). Everything came up healthy and all ingress worked fine in a quick test.

Closes https://github.com/defenseunicorns/uds-package-dubbd/issues/221