### PR TITLE
DUBBD-AWS Upgrade Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pre-built Zarf Package of [DoD-Platform-One/big-bang](https://github.com/DoD-Pla
 
 ## Prerequisites
 
-- Zarf is installed locally with a minimum version of [v0.26.1](https://github.com/defenseunicorns/zarf/releases/tag/v0.26.1)
+- Zarf is installed locally with a minimum version of [v0.27.1](https://github.com/defenseunicorns/zarf/releases/tag/v0.27.1)
 - Optional: A working Kubernetes cluster on v1.26+ -- e.g k3d, k3s, KinD, etc (Zarf can be used to deploy a built-in k3s distribution)
 - Working kube context (`kubectl get nodes` <-- this command works)
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -155,7 +155,7 @@ zarf tools kubectl get pod -A
 - Verify AWS resources exist (S3 bucket for Loki, Load Balancers for Istio): This can be confirmed via your AWS console or CLI access
 
 ### Upgrade Steps
-Follow the same steps as used for initial deployment from the [configure DUBBD](#configure-DUBBD-AWS) and [deploy the package](#deploy-the-package) sections.
+Follow the same steps as used for initial deployment from the [configure DUBBD](#configure-dubbd-aws) and [deploy the package](#deploy-the-package) sections.
 
 ### Post upgrade validation
 After the upgrade is complete, here are some recommended validation activities:

--- a/aws/README.md
+++ b/aws/README.md
@@ -49,8 +49,6 @@ package:
       state_dynamodb_table_name: uds-dev-state-dynamodb
       # -- AWS region
       region: us-west-2
-      # -- Bring your own kms key, if omitted a key will be created with an alias prefix of "<cluster name>-loki-"
-      #loki_kms_key_arn: "arn:aws:kms:us-west-2:000000000000:key/mrk-0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"
       # -- if set to true, delete the S3 bucket and corresponding KMS key associated with the Loki bucket
       #loki_force_destroy: "true"
 ```

--- a/aws/README.md
+++ b/aws/README.md
@@ -27,7 +27,8 @@ zarf package create --architecture amd64 --confirm
 ```
 
 ## Configure DUBBD-AWS
-The recommended way to configure DUBBD-AWS is via a `zarf-config.yaml` file located in the same directory that you will be performing the deploy in. The available `zarf-config.yaml` configurations are shown below, note the keys that are not commented out are **required** to deploy DUBBD-AWS. 
+The recommended way to configure DUBBD-AWS is via a `zarf-config.yaml` file located in the same directory that you will be performing the deploy. The available `zarf-config.yaml` configurations are shown below. 
+> Note the keys that are not commented out are **required** to deploy DUBBD-AWS. 
 
 ```yaml
 package:  
@@ -72,8 +73,7 @@ zarf package deploy --confirm zarf-package-dubbd-aws-*.tar.zst
 
 ## Additional Information
 
-When running Big Bang on AWS, Loki is configured to use S3 for storage for better persistance.  The Zarf package for DUBBD-AWS is created by overlaying a
-new loki values file on top of the existing DUBBD zarf file via:
+When running Big Bang on AWS, Loki is configured to use S3 for storage for better persistance.  The Zarf package for DUBBD-AWS is created by overlaying a new loki values file on top of the existing DUBBD zarf file via:
 
 ```yaml
 - name: bigbang
@@ -102,31 +102,31 @@ Zarf does not expose the current version of your DUBBD deployment, but this may 
 - Get the DUBBD version deployed with `kubectl`+`jq`
 
 ```console
-# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
+zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
 ```
 
 - If you don't have access to `jq` run this alternative command and review the output to find the `data.metadata.version` value manually
 
 ```console
-# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}"
+zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}"
 ```
 
 - Get the corresponding Big Bang version that is deployed
 
 ```console
-# zarf tools kubectl get helmrelease -n bigbang bigbang -o jsonpath='{.status.lastAppliedRevision}'`
+zarf tools kubectl get helmrelease -n bigbang bigbang -o jsonpath='{.status.lastAppliedRevision}'`
 ```
 
 #### Determine target upgrade version
 
-It's best to stay up to date with the latest DUBBD version to ensure you have the latest security patches for applications as well as the latest features and fixes from DUBBD. Typically you should target the latest patch version for a given minor version you are planning to update to. Supported (and recommended) upgrade paths can be reviewed in the matrix below - in general you can jump multiple patch versions but only a single major/minor patch version.
+It's best to stay up to date with the latest DUBBD version to ensure you have the latest security patches for applications as well as the latest features and fixes from DUBBD. Typically your upgrade should target the latest patch version for a given minor version, e.g. `0.2.4` and not `0.2.3`.  Supported (and recommended) upgrade paths can be reviewed in the matrix below - in general you can jump multiple patch versions but only a single major/minor patch version.
 
 | Current Version | Supported Upgrade Version(s) | Recommended Upgrade Version |
 |-|-|-|
 | 0.2.\* | 0.2.\* | Latest 0.2.x patch version |
 | 0.1.\* | 0.1.\*, 0.2.\* | Latest 0.2.x patch version |
 
-If you are not on a supported upgrade path, you will need to review release notes and test the upgrade path on your own. If you have fallen behind several versions we recommend doing consecutive upgrades of the intermediate versions (ex: 0.1.0 -> 0.2.0 -> 0.3.0) or at minimum testing the upgrade jump in a staging environment.
+If you are not on a supported upgrade path, you will need to review the release notes and test the intended upgrade path on your own. If you have fallen behind several versions we recommend doing consecutive upgrades of the intermediate versions (ex: `0.1.0` -> `0.2.0` -> `0.3.0`) or at minimum testing the upgrade jump in a staging environment.
 
 #### Verify DUBBD health
 
@@ -135,172 +135,128 @@ Prior to upgrading you should confirm that your current deployment is healthy. A
 
 ```console
 ## The `STATUS` column should show `Release reconciliation succeeded` for all helmreleases
-# zarf tools kubectl get hr -n bigbang -l app.kubernetes.io/part-of=bigbang`
+zarf tools kubectl get hr -n bigbang -l app.kubernetes.io/part-of=bigbang`
 ```
 
 - Confirm that all flux pods are running
 
 ```console
 ## Pods should have a `STATUS` of `Running` and show as `READY` `1/1`
-# zarf tools kubectl get pod -n flux-system
+zarf tools kubectl get pod -n flux-system
 ```
 
 - Confirm that all DUBBD pods are running
 
 ```console
 ## This will output all pods in all namespaces, check for `STATUS` of `Running` and `READY` `x/x`
-# zarf tools kubectl get pod -A
+zarf tools kubectl get pod -A
 ```
 
 - Verify AWS resources exist (S3 bucket for Loki, Load Balancers for Istio): This can be confirmed via your AWS console or CLI access
 
 ### Upgrade Steps
-​
 Follow the same steps as used for initial deployment from the [configure DUBBD](#configure-DUBBD-AWS) and [deploy the package](#deploy-the-package) sections.
 
 ### Post upgrade validation
-​
 After the upgrade is complete, here are some recommended validation activities:
-​
 - Confirm the deployed DUBBD version is correct
-​
 ```console
 # zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
 ```
-​
 - Perform the same steps outlined in [Verify DUBBD health](#verify-dubbd-health)
-​
 - Test BigBang functionality works (ex: Grafana, Kiali, Neuvector, Tempo, etc)
-​
 ### (Optional) Rollback
-​
 If a rollback is deemed necessary, these are the various options:
-​
 #### OPTION 1: Deploy a previous working version of the DUBBD package
-​
 - Grab the version of the deployed DUBBD package
-​
 ```console
-# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
+zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
 ```
-​
 - Prep the zarf-config.yaml for use with the previous DUBBD version
-​
 - Deploy previous version of DUBBD
-​
 ```console
-# zarf package deploy oci://ghcr.io/defenseunicorns/packages/dubbd-aws:(PREVIOUS-VERSION)-amd64
+zarf package deploy oci://ghcr.io/defenseunicorns/packages/dubbd-aws:(PREVIOUS-VERSION)-amd64
 ```
-​
 #### OPTION 2: Remove DUBBD package and re-deploy a previous working version
-​
 - Grab the version of the deployed DUBBD package
-​
 ```console
-# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
+zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
 ```
-```
-​
+
 - Remove the DUBBD package (execute command from same directory used to deploy)
-​
 ```console
-# zarf package remove dubbd-aws --confirm
+zarf package remove dubbd-aws --confirm
 ```
-​
 - Prep the zarf-config.yaml for use with the previous DUBBD version
-​
 - Deploy previous version of DUBBD
-​
 ```console
-# zarf package deploy oci://ghcr.io/defenseunicorns/packages/dubbd-aws:(PREVIOUS-VERSION)-amd64
+zarf package deploy oci://ghcr.io/defenseunicorns/packages/dubbd-aws:(PREVIOUS-VERSION)-amd64
 ```
-​
-#### OPTION 3: Helm rollback of the DUBBD helm releases (Terraform needed to be handled separately)
-​
+#### OPTION 3: Helm rollback of the DUBBD helm releases (Terraform needs to be handled separately)
 - Get the DUBBD managed umbrella helm chart name
-​
 ```sh
 export DUBBD_HELM_RELEASE=$(helm ls -n bigbang -f 'zarf-[\w\[\]]+' --no-headers --short)
 export DUBBD_FLUX_HELM_RELEASE=$(helm ls -n flux-system -f 'zarf-[\w\[\]]+' --no-headers --short)
 ```
-​
 - View the helm history of the helm releases
-​
 ```sh
 helm history -n bigbang ${DUBBD_HELM_RELEASE}
 helm history -n flux-system ${DUBBD_FLUX_HELM_RELEASE}
 ```
-​
 - Roll back to previous helm chart version
-​
 ```sh
 helm rollback -n bigbang ${DUBBD_HELM_RELEASE}
 helm rollback -n flux-system ${DUBBD_FLUX_HELM_RELEASE}
 ```
-​
 - Check the updated helm history of the DUBBD managed umbrella helm release name
-​
 ```sh
 helm history -n bigbang ${DUBBD_HELM_RELEASE}
 helm history -n flux-system ${DUBBD_FLUX_HELM_RELEASE}
 ```
-​
 ## Troubleshooting issues
-​
-- If the DUBBD deploy failed with errors, inspect the output that should have run commands like these
-​
+- If the DUBBD deploy fails with errors the output should have run commands like these
 ```console
-# zarf tools kubectl describe helmrelease -n bigbang $hr
-# zarf tools kubectl get nodes -o wide
-# zarf tools kubectl get hr -n bigbang
-# zarf tools kubectl get gitrepo -n bigbang
-# zarf tools kubectl get pods -A
+zarf tools kubectl describe helmrelease -n bigbang $hr
+zarf tools kubectl get nodes -o wide
+zarf tools kubectl get hr -n bigbang
+zarf tools kubectl get gitrepo -n bigbang
+zarf tools kubectl get pods -A
 ERROR:  Failed to deploy package: unable to deploy all components in this Zarf Package: unable to run
         component success action: command "Big Bang Helm Release `Failed-Helm-Release-Name` to be 
         ready" failed after 0 retries
 ```
-​
-- Confirm zarf init was performed and components are in-place / healthy
-​
+- Confirm `zarf init` was performed and components are in-place / healthy
 ```console
-# zarf tools kubectl get mutatingwebhookconfigurations zarf
-# zarf tools kubectl get all -n zarf
+zarf tools kubectl get mutatingwebhookconfigurations zarf
+zarf tools kubectl get all -n zarf
 ```
-​
 - Confirm sufficient capacity on the cluster
-​
 ```console
 ## Look for events and info under "Allocated resources:"
-# zarf tools kubectl describe node
-# zarf tools kubectl top node
+zarf tools kubectl describe node
+zarf tools kubectl top node
 ```
-​
 - Confirm storage is being allocated as desired
-​
 ```console
-# zarf tools kubectl get pv,pvc -A
+zarf tools kubectl get pv,pvc -A
 ```
-​
 - Check helm releases
-​
 ```console
-# helm ls -A
-# helm history -n bigbang <helm-release-name>
-# helm get all -n bigbang <helm-release-name>
+helm ls -A
+helm history -n bigbang <helm-release-name>
+helm get all -n bigbang <helm-release-name>
 ```
-​
 - Check Istio is properly configured and logs for errors
-​
 ```console
-# zarf tools kubectl get svc -n istio-system
-# zarf tools kubectl logs -n istio-system deploy/admin-ingressgateway --all-containers=true -f
-# zarf tools kubectl logs -n istio-system deploy/tenant-ingressgateway --all-containers=true -f
+zarf tools kubectl get svc -n istio-system
+zarf tools kubectl logs -n istio-system deploy/admin-ingressgateway --all-containers=true -f
+zarf tools kubectl logs -n istio-system deploy/tenant-ingressgateway --all-containers=true -f
 ```
 
 - Check the zarf debug log file for additional information
 
 ```console
-# ls -ldrta /tmp/zarf*
-# export ZARF_LOG_FILE=/tmp/<zarf-log-name>.log
-# ansi2txt < ${ZARF_LOG_FILE} | col -b | view -
+ls -ldrta /tmp/zarf*
+export ZARF_LOG_FILE=/tmp/<zarf-log-name>.log
+ansi2txt < ${ZARF_LOG_FILE} | col -b | view -
 ```

--- a/aws/README.md
+++ b/aws/README.md
@@ -56,10 +56,11 @@ package:
 ```
 
 ## Deploy the package
+
 Once all of the prereqs are met and the `zarf-config.yaml` has been configured:
 ```bash
 # To deploy from OCI (recommended)
-zarf package deploy oci://ghcr.io/defenseunicorns/packages/big-bang-distro-aws:<VERSION>-amd64 \
+zarf package deploy oci://ghcr.io/defenseunicorns/packages/dubbd-aws:<VERSION>-amd64 \
   --oci-concurrency=15 \
   --confirm
 ```
@@ -68,10 +69,8 @@ Note that package versions can be found in the [Defense Unicorns GHCR repo](http
 
 If developing locally:
 ```bash
-zarf package deploy --confirm zarf-package-big-bang-*.tar.zst
+zarf package deploy --confirm zarf-package-dubbd-aws-*.tar.zst
 ```
-
-
 
 ## Additional Information
 
@@ -96,20 +95,213 @@ In order for this configuration to work cleanly, DUBBD-AWS also provisions an S3
 
 ### Before upgrading
 
-#### Get the current version
+It is important to take a few steps before the upgrade to confirm you are on a supported upgrade path and that your DUBBD deployment is in a healthy state.
 
-#### Decide on upgrade version
+#### Get current deployed version
 
-#### Supported upgrade version check
+Zarf does not expose the current version of your DUBBD deployment, but this may be an option in the future (see [this issue](https://github.com/defenseunicorns/zarf/issues/1797) to track the progress of that functionality). 
 
-#### Verify BB health
+- Get the DUBBD version deployed with `kubectl`+`jq`
+
+```console
+# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
+```
+
+- If you don't have access to `jq` run this alternative command and review the output to find the `data.metadata.version` value manually
+
+```console
+# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}"
+```
+
+- Get the corresponding Big Bang version that is deployed
+
+```console
+# zarf tools kubectl get helmrelease -n bigbang bigbang -o jsonpath='{.status.lastAppliedRevision}'`
+```
+
+#### Determine target upgrade version
+
+It's best to stay up to date with the latest DUBBD version to ensure you have the latest security patches for applications as well as the latest features and fixes from DUBBD. Typically you should target the latest patch version for a given minor version you are planning to update to. Supported (and recommended) upgrade paths can be reviewed in the matrix below - in general you can jump multiple patch versions but only a single major/minor patch version.
+
+| Current Version | Supported Upgrade Version(s) | Recommended Upgrade Version |
+|-|-|-|
+| 0.2.\* | 0.2.\* | Latest 0.2.x patch version |
+| 0.1.\* | 0.1.\*, 0.2.\* | Latest 0.2.x patch version |
+
+If you are not on a supported upgrade path, you will need to review release notes and test the upgrade path on your own. If you have fallen behind several versions we recommend doing consecutive upgrades of the intermediate versions (ex: 0.1.0 -> 0.2.0 -> 0.3.0) or at minimum testing the upgrade jump in a staging environment.
+
+#### Verify DUBBD health
+
+Prior to upgrading you should confirm that your current deployment is healthy. A few basic checks are included below:
+- Confirm that all helmreleases have reconciled
+
+```console
+## The `STATUS` column should show `Release reconciliation succeeded` for all helmreleases
+# zarf tools kubectl get hr -n bigbang -l app.kubernetes.io/part-of=bigbang`
+```
+
+- Confirm that all flux pods are running
+
+```console
+## Pods should have a `STATUS` of `Running` and show as `READY` `1/1`
+# zarf tools kubectl get pod -n flux-system
+```
+
+- Confirm that all DUBBD pods are running
+
+```console
+## This will output all pods in all namespaces, check for `STATUS` of `Running` and `READY` `x/x`
+# zarf tools kubectl get pod -A
+```
+
+- Verify AWS resources exist (S3 bucket for Loki, Load Balancers for Istio): This can be confirmed via your AWS console or CLI access
 
 ### Upgrade Steps
-
-### Monitor upgrade progress
+​
+Follow the same steps as used for initial deployment from the [configure DUBBD](#configure-DUBBD-AWS) and [deploy the package](#deploy-the-package) sections.
 
 ### Post upgrade validation
-
+​
+After the upgrade is complete, here are some recommended validation activities:
+​
+- Confirm the deployed DUBBD version is correct
+​
+```console
+# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
+```
+​
+- Perform the same steps outlined in [Verify DUBBD health](#verify-dubbd-health)
+​
+- Test BigBang functionality works (ex: Grafana, Kiali, Neuvector, Tempo, etc)
+​
 ### (Optional) Rollback
-
+​
+If a rollback is deemed necessary, these are the various options:
+​
+#### OPTION 1: Deploy a previous working version of the DUBBD package
+​
+- Grab the version of the deployed DUBBD package
+​
+```console
+# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o jsonpath='{.data.data}' | base64 -d | jq -r '.data.metadata.version'
+```
+​
+- Prep the zarf-config.yaml for use with the previous DUBBD version
+​
+- Deploy previous version of DUBBD
+​
+```console
+# zarf package deploy oci://ghcr.io/defenseunicorns/packages/dubbd-aws:(PREVIOUS-VERSION)-amd64
+```
+​
+#### OPTION 2: Remove DUBBD package and re-deploy a previous working version
+​
+- Grab the version of the deployed DUBBD package
+​
+```console
+# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o jsonpath='{.data.data}' | base64 -d | jq -r '.data.metadata.version'
+```
+​
+- Remove the DUBBD package (execute command from same directory used to deploy)
+​
+```console
+# zarf package remove dubbd-aws --confirm
+```
+​
+- Prep the zarf-config.yaml for use with the previous DUBBD version
+​
+- Deploy previous version of DUBBD
+​
+```console
+# zarf package deploy oci://ghcr.io/defenseunicorns/packages/dubbd-aws:(PREVIOUS-VERSION)-amd64
+```
+​
+#### OPTION 3: Helm rollback of the DUBBD helm releases (Terraform needed to be handled separately)
+​
+- Get the DUBBD managed umbrella helm chart name
+​
+```sh
+export DUBBD_HELM_RELEASE=$(helm ls -n bigbang -f 'zarf-[\w\[\]]+' --no-headers --short)
+export DUBBD_FLUX_HELM_RELEASE=$(helm ls -n flux-system -f 'zarf-[\w\[\]]+' --no-headers --short)
+```
+​
+- View the helm history of the helm releases
+​
+```sh
+helm history -n bigbang ${DUBBD_HELM_RELEASE}
+helm history -n flux-system ${DUBBD_FLUX_HELM_RELEASE}
+```
+​
+- Roll back to previous helm chart version
+​
+```sh
+helm rollback -n bigbang ${DUBBD_HELM_RELEASE}
+helm rollback -n flux-system ${DUBBD_FLUX_HELM_RELEASE}
+```
+​
+- Check the updated helm history of the DUBBD managed umbrella helm release name
+​
+```sh
+helm history -n bigbang ${DUBBD_HELM_RELEASE}
+helm history -n flux-system ${DUBBD_FLUX_HELM_RELEASE}
+```
+​
 ## Troubleshooting issues
+​
+- If the DUBBD deploy failed with errors, inspect the output that should have run commands like these
+​
+```console
+# zarf tools kubectl describe helmrelease -n bigbang $hr
+# zarf tools kubectl get nodes -o wide
+# zarf tools kubectl get hr -n bigbang
+# zarf tools kubectl get gitrepo -n bigbang
+# zarf tools kubectl get pods -A
+ERROR:  Failed to deploy package: unable to deploy all components in this Zarf Package: unable to run
+        component success action: command "Big Bang Helm Release `Failed-Helm-Release-Name` to be 
+        ready" failed after 0 retries
+```
+​
+- Confirm zarf init was performed and components are in-place / healthy
+​
+```console
+# zarf tools kubectl get mutatingwebhookconfigurations zarf
+# zarf tools kubectl get all -n zarf
+```
+​
+- Confirm sufficient capacity on the cluster
+​
+```console
+## Look for events and info under "Allocated resources:"
+# zarf tools kubectl describe node
+# zarf tools kubectl top node
+```
+​
+- Confirm storage is being allocated as desired
+​
+```console
+# zarf tools kubectl get pv,pvc -A
+```
+​
+- Check helm releases
+​
+```console
+# helm ls -A
+# helm history -n bigbang <helm-release-name>
+# helm get all -n bigbang <helm-release-name>
+```
+​
+- Check Istio is properly configured and logs for errors
+​
+```console
+# zarf tools kubectl get svc -n istio-system
+# zarf tools kubectl logs -n istio-system deploy/admin-ingressgateway --all-containers=true -f
+# zarf tools kubectl logs -n istio-system deploy/tenant-ingressgateway --all-containers=true -f
+```
+
+- Check the zarf debug log file for additional information
+
+```console
+# ls -ldrta /tmp/zarf*
+# export ZARF_LOG_FILE=/tmp/<zarf-log-name>.log
+# ansi2txt < ${ZARF_LOG_FILE} | col -b | view -
+```

--- a/aws/README.md
+++ b/aws/README.md
@@ -91,3 +91,25 @@ new loki values file on top of the existing DUBBD zarf file via:
 ```
 
 In order for this configuration to work cleanly, DUBBD-AWS also provisions an S3 bucket from our [IaC Repo](https://github.com/defenseunicorns/terraform-aws-uds-s3) that provides encryption at rest and a role to access the S3 bucket that gets used by Loki via [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+
+## DUBBD upgrade
+
+### Before upgrading
+
+#### Get the current version
+
+#### Decide on upgrade version
+
+#### Supported upgrade version check
+
+#### Verify BB health
+
+### Upgrade Steps
+
+### Monitor upgrade progress
+
+### Post upgrade validation
+
+### (Optional) Rollback
+
+## Troubleshooting issues

--- a/aws/README.md
+++ b/aws/README.md
@@ -183,7 +183,7 @@ If a rollback is deemed necessary, these are the various options:
 - Grab the version of the deployed DUBBD package
 ​
 ```console
-# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o jsonpath='{.data.data}' | base64 -d | jq -r '.data.metadata.version'
+# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
 ```
 ​
 - Prep the zarf-config.yaml for use with the previous DUBBD version
@@ -199,7 +199,8 @@ If a rollback is deemed necessary, these are the various options:
 - Grab the version of the deployed DUBBD package
 ​
 ```console
-# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o jsonpath='{.data.data}' | base64 -d | jq -r '.data.metadata.version'
+# zarf tools kubectl get secret -n zarf zarf-package-dubbd-aws -o go-template="{{ .data.data | base64decode }}" | jq -r '.data.metadata.version'
+```
 ```
 ​
 - Remove the DUBBD package (execute command from same directory used to deploy)

--- a/k3d/README.md
+++ b/k3d/README.md
@@ -37,12 +37,12 @@ zarf package create --architecture amd64 --confirm
 # Verify all prereqs are met
 
 # Run the zarf package deploy command
-zarf package deploy --confirm zarf-package-big-bang-*.tar.zst
+zarf package deploy --confirm zarf-package-dubbd-*.tar.zst
 
 # (Alternatively) Deploy from OCI
 # Login to the registry
 # Run the zarf package deploy command with the desired DUBBD OCI package reference 
-zarf package deploy oci://ghcr.io/defenseunicorns/packages/big-bang-distro-k3d/big-bang-distro-k3d:0.0.1-amd64 --oci-concurrency=15
+zarf package deploy oci://ghcr.io/defenseunicorns/packages/dubbd-k3d:0.0.1-amd64 --oci-concurrency=15
 ```
 
 ## Additional Information


### PR DESCRIPTION
Adds upgrade documentation for DUBBD-AWS. Also fixes a few spots with the wrong package name.

Preview rendered: https://github.com/defenseunicorns/uds-package-dubbd/blob/aws-docs/aws/README.md

Closes https://github.com/defenseunicorns/uds-package-dubbd/issues/14