### PR TITLE
chore: Publish skeleton and DUBBD core

### DIFF
--- a/.github/workflows/publish.dubbd.package.yaml
+++ b/.github/workflows/publish.dubbd.package.yaml
@@ -37,3 +37,8 @@ jobs:
         run: zarf package publish zarf-package-*.tar.zst oci://ghcr.io/defenseunicorns/packages
         working-directory: ${{ inputs.working_dir }}
         timeout-minutes: 60
+
+      - name: Publish Zarf Skeleton
+        run: zarf package publish . oci://ghcr.io/defenseunicorns/packages
+        working-directory: ${{ inputs.working_dir }}
+        timeout-minutes: 60

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -41,3 +41,11 @@ jobs:
     with:
       working_dir: k3d
     secrets: inherit
+
+  publish-dubbd-core:
+    needs: tag-new-version
+    if: ${{ needs.tag-new-version.outputs.release_created == 'true'}}
+    uses: ./.github/workflows/publish.dubbd.package.yaml
+    with:
+      working_dir: defense-unicorns-distro
+    secrets: inherit


### PR DESCRIPTION
Adds a publish skeleton step to the DUBBD publishing workflow.

Also adds a job to publish core DUBBD.

With this addition every release would publish 6 packages: aws/k3d/"core" package+skeleton


BEGIN_COMMIT_OVERRIDE
chore: publish skeleton packages and DUBBD core package
END_COMMIT_OVERRIDE
