### PR TITLE
ci: config temp set releases to patch only

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
       "release-type": "simple",
       "draft": false,
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": "true",
-      "bump-patch-for-minor-pre-major": "true",
+      "versioning": "always-bump-patch",
       "extra-files": [
         "aws/zarf.yaml",
         "defense-unicorns-distro/zarf.yaml",


### PR DESCRIPTION
temporary change so all versions are patches (for now)

manual override option: still can force a version with a commit message:
```sh
git commit --allow-empty -m "chore: release 0.3.0" -m "Release-As: 0.3.0"
```