### PR TITLE
feat: allow configuring public/private tenant LB

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -50,6 +50,8 @@ package:
       state_dynamodb_table_name: uds-dev-state-dynamodb
       # -- AWS region
       region: us-west-2
+      # -- Provision a private/internal load balancer for the tenant ingress gateway, if false a public load balancer will be provisioned
+      private_tenant_lb: true
       # -- if set to true, delete the S3 bucket and corresponding KMS key associated with the Loki bucket
       #loki_force_destroy: "true"
 ```

--- a/aws/values/aws-istio.yaml
+++ b/aws/values/aws-istio.yaml
@@ -3,7 +3,7 @@ istio:
     admin-ingressgateway:
       kubernetesResourceSpec:
         serviceAnnotations:
-          service.beta.kubernetes.io/aws-load-balancer-internal: "###ZARF_VAR_PRIVATE_TENANT_LB###"
+          service.beta.kubernetes.io/aws-load-balancer-internal: "true"
           service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     tenant-ingressgateway:
       kubernetesResourceSpec:

--- a/aws/values/aws-istio.yaml
+++ b/aws/values/aws-istio.yaml
@@ -3,10 +3,10 @@ istio:
     admin-ingressgateway:
       kubernetesResourceSpec:
         serviceAnnotations:
-          service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+          service.beta.kubernetes.io/aws-load-balancer-internal: "###ZARF_VAR_PRIVATE_TENANT_LB###"
           service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     tenant-ingressgateway:
       kubernetesResourceSpec:
         serviceAnnotations:
-          service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+          service.beta.kubernetes.io/aws-load-balancer-internal: "###ZARF_VAR_PRIVATE_TENANT_LB###"
           service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"

--- a/aws/zarf-config.yaml
+++ b/aws/zarf-config.yaml
@@ -26,8 +26,9 @@ package:
       state_dynamodb_table_name: uds-dev-state-dynamodb
       # -- AWS region
       region: us-west-2
+      # -- Provision a private/internal load balancer for the tenant ingress gateway, if false a public load balancer will be provisioned
+      private_tenant_lb: true
       # -- Bring your own kms key, if omitted a key will be created with an alias prefix of "<cluster name>-loki-"
       #loki_kms_key_arn: "arn:aws:kms:us-west-2:000000000000:key/mrk-0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"
       # -- If set to true, delete the S3 bucket and corresponding KMS key associated with the Loki bucket
       #loki_force_destroy: "true"
-

--- a/aws/zarf.yaml
+++ b/aws/zarf.yaml
@@ -158,7 +158,7 @@ components:
       onDeploy:
         before:
           - cmd: |
-              if [[ "$(./zarf tools kubectl get svc -n istio-system tenant-ingressgateway -o jsonpath='{.metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal}')" == "${ZARF_VAR_PRIVATE_TENANT_LB}" ]]; then
+              if [[ "$(./zarf tools kubectl get svc -n istio-system tenant-ingressgateway -o jsonpath='{.metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal}' 2>/dev/null)" == "${ZARF_VAR_PRIVATE_TENANT_LB}" ]]; then
                 echo false
               else
                 echo true

--- a/aws/zarf.yaml
+++ b/aws/zarf.yaml
@@ -28,6 +28,10 @@ variables:
 - name: REGION
   description: "The AWS region to run the Terraform in"
 
+- name: PRIVATE_TENANT_LB
+  description: "Provision a private/internal load balancer for the tenant ingress gateway"
+  default: "true"
+
 - name: LOKI_FORCE_DESTROY
   description: "Provide a means to force destroy the Loki storage (S3) bucket even if it contains data"
   default: "false"
@@ -150,3 +154,30 @@ components:
         valuesFiles:
         - values/aws-istio.yaml
         - values/aws-loki.yaml
+    actions:
+      onDeploy:
+        before:
+          - cmd: |
+              if [[ "$(./zarf tools kubectl get svc -n istio-system tenant-ingressgateway -o jsonpath='{.metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal}')" == "${ZARF_VAR_PRIVATE_TENANT_LB}" ]]; then
+                echo false
+              else
+                echo true
+              fi
+            description: "Check if tenant ingressgateway needs an update"
+            mute: true
+            setVariables:
+              - name: TENANT_INGRESS_UPDATE
+  - name: dubbd-upgrade
+    required: true
+    actions:
+      onDeploy:
+        after:
+          - cmd: |
+              if [[ "${ZARF_VAR_IS_UPGRADE}" == "true" ]]; then
+                if [[ "${ZARF_VAR_TENANT_INGRESS_UPDATE}" == "true" ]]; then
+                  ./zarf tools kubectl delete svc -n istio-system tenant-ingressgateway
+                  echo "Tenant ingress gateway conifugration was updated. You may need to update DNS records to point to the newly provisioned loadbalancer."
+                  echo "The new hostname can be pulled with: zarf tools kubectl get svc -n istio-system tenant-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"
+                fi
+              fi
+            description: "Perform DUBBD upgrade steps"


### PR DESCRIPTION
Changes:
- Adds a `private_tenant_lb` zarf var to configure whether the provisioned tenant elastic loadbalancer is public or private
- Adds actions before/after to cycle the tenant loadbalancer service if this value changes on an upgrade (ensures a new ELB is provisioned)

Notes:
- all logic was added to the AWS package as it is currently AWS specific but we could move to "core" DUBBD in the future if other flavors require the same variable/functionality
- bash scripting is not intended to be the final solution for "upgrade logic" - there are other proposed routes of doing things in a more programmatic approach w/testing, etc but as there is not a clear decision on that approach yet this was done with basic scripting
- this basic pattern would likely apply to all future upgrade logic as well - `onDeploy.before` actions to check before state, then a final component to take action based on said state

Closes https://github.com/defenseunicorns/uds-package-dubbd/issues/297