### PR TITLE
fix: Update workflow path filters

### DIFF
--- a/.github/workflows/ci-on-pull-request-aws.yaml
+++ b/.github/workflows/ci-on-pull-request-aws.yaml
@@ -4,11 +4,14 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/ci-on-pull-request-aws.y*ml"
-      - "aws/**"
-      - "defense-unicorns-distro/**"
-      - "values/**"
+    paths-ignore:
+      - ".gitignore"
+      - "LICENSE"
+      - "**.md"
+      - "**.json"
+      - "k3d/**"
+      - ".github/workflows/ci-on-pull-request-k3d.y*ml"
+      - ".github/workflows/test-k3d-package.y*ml"
   workflow_call:
 
 jobs:

--- a/.github/workflows/ci-on-pull-request-aws.yaml
+++ b/.github/workflows/ci-on-pull-request-aws.yaml
@@ -4,8 +4,11 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**/README.md'
+    paths:
+      - ".github/workflows/ci-on-pull-request-aws.y*ml"
+      - "aws/**"
+      - "defense-unicorns-distro/**"
+      - "values/**"
   workflow_call:
 
 jobs:

--- a/.github/workflows/ci-on-pull-request-k3d.yaml
+++ b/.github/workflows/ci-on-pull-request-k3d.yaml
@@ -4,13 +4,15 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/ci-on-pull-request-k3d.y*ml"
-      - "defense-unicorns-distro/**"
-      - "values/**"
-      - "k3d/values/**"
-      - "k3d/zarf-config.y*ml"
-      - "k3d/zarf.y*ml"
+    paths-ignore:
+      - ".gitignore"
+      - "LICENSE"
+      - "**.md"
+      - "**.json"
+      - "aws/**"
+      - ".github/workflows/ci-on-pull-request-aws.y*ml"
+      - ".github/workflows/test-aws-package.y*ml"
+      - ".github/workflows/test-aws-upgrade.y*ml"
 
 jobs:
   test-release:

--- a/.github/workflows/ci-on-pull-request-k3d.yaml
+++ b/.github/workflows/ci-on-pull-request-k3d.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".github/workflows/ci-on-pull-request-k3d.y*ml"
       - "defense-unicorns-distro/**"
+      - "values/**"
       - "k3d/values/**"
       - "k3d/zarf-config.y*ml"
       - "k3d/zarf.y*ml"


### PR DESCRIPTION
Relates to https://github.com/defenseunicorns/uds-package-dubbd/issues/216

Adds file paths in the workflows that are ignored, so that when there are changes to them, the workflows are not triggered

This creates a faster feedback loop by not running the pipelines for changes that do not impact the package or the pipelines themselves. For example, if I make a change to only the k3d package, only the k3d pipeline will run, and the AWS/EKS pipeline will be skipped because there are no changes to the AWS package or pipelines.