### PR TITLE
chore: standardize workflow rules with paths-ignore

### DIFF
--- a/.github/workflows/ci-on-pull-request-dubbd-aws.yaml
+++ b/.github/workflows/ci-on-pull-request-dubbd-aws.yaml
@@ -4,17 +4,14 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "aws/dubbd-aws/**"
-      - "aws/values/**"
-      - "aws/loki/**"
-      - "!.gitignore"
-      - "!LICENSE"
-      - "!**.md"
-      - "!**.json"
-      - "!k3d/**"
-      - "!.github/workflows/ci-on-pull-request-k3d.y*ml"
-      - "!.github/workflows/test-k3d-package.y*ml"
+    paths-ignore:
+      - ".gitignore"
+      - "LICENSE"
+      - "**.md"
+      - "**.json"
+      - "aws/uds-core-aws/**"
+      - "k3d/**"
+      - ".github/workflows/**k3d**.y*ml"
   workflow_call:
 
 jobs:

--- a/.github/workflows/ci-on-pull-request-uds-core-aws.yaml
+++ b/.github/workflows/ci-on-pull-request-uds-core-aws.yaml
@@ -4,16 +4,13 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "aws/uds-core-aws/**"
-      - "aws/values/**"
-      - "aws/loki/**"
-      - "!LICENSE"
-      - "!**.md"
-      - "!**.json"
-      - "!k3d/**"
-      - "!.github/workflows/ci-on-pull-request-k3d.y*ml"
-      - "!.github/workflows/test-k3d-package.y*ml"
+    paths-ignore:
+      - ".gitignore"
+      - "LICENSE"
+      - "**.md"
+      - "**.json"
+      - "k3d/**"
+      - ".github/workflows/**k3d**.y*ml"
   workflow_call:
 
 jobs:


### PR DESCRIPTION
Standardizes around `paths-ignore` for all workflows to match k3d. Ensures that workflow changes + changes to "DUBBD vanilla" trigger a CI run since AWS imports from there.