### PR TITLE
Use downloaded Terraform binary for a Zarf deploy.

### DIFF
--- a/aws/dubbd-aws/zarf.yaml
+++ b/aws/dubbd-aws/zarf.yaml
@@ -94,24 +94,24 @@ components:
           - cmd: "test -d ./loki/ && chmod -R ugo+rwx ./loki/ || echo $?"
             dir: run
           - cmd: |
-              terraform init -force-copy \
+              ../terraform init -force-copy \
               -backend-config="bucket=${ZARF_VAR_STATE_BUCKET_NAME}" \
               -backend-config="key=loki-${ZARF_VAR_STATE_KEY}" \
               -backend-config="region=${ZARF_VAR_REGION}" \
               -backend-config="dynamodb_table=${ZARF_VAR_STATE_DYNAMODB_TABLE_NAME}"
             dir: run/loki
-          - cmd: terraform plan
+          - cmd: ../terraform plan
             dir: run/loki
           - cmd: sleep 15 #time to review
-          - cmd: terraform apply -auto-approve
+          - cmd: ../terraform apply -auto-approve
             dir: run/loki
       onRemove:
         before:
           - cmd: |
               if [ -d "run/loki" ]; then
                 cd run/loki
-                if [ "$(terraform output force_destroy)" = true ]; then
-                  terraform destroy -auto-approve
+                if [ "$(../terraform output force_destroy)" = true ]; then
+                  ../terraform destroy -auto-approve
                 else
                   echo "Skipping remove, force_destroy is set to false"
                 fi
@@ -123,15 +123,15 @@ components:
     actions:
       onDeploy:
         after:
-          - cmd: terraform output -raw s3_bucket
+          - cmd: ../terraform output -raw s3_bucket
             dir: run/loki
             setVariables:
               - name: LOKI_S3_BUCKET
-          - cmd: terraform output -raw aws_region
+          - cmd: ../terraform output -raw aws_region
             dir: run/loki
             setVariables:
               - name: LOKI_S3_AWS_REGION
-          - cmd: terraform output -raw irsa_role
+          - cmd: ../terraform output -raw irsa_role
             dir: run/loki
             setVariables:
               - name: LOKI_S3_ROLE_ARN

--- a/aws/extract.sh
+++ b/aws/extract.sh
@@ -37,4 +37,4 @@ echo "ARCH_PROC: ${ARCH_PROC}"
 # todo: actually use the terraform binary we download
 #mkdir -p run/loki
 #mkdir -p run/eks
-#unzip -o -q tmp/terraform_${1}_${ARCH_NAME}_${ARCH_PROC}.zip -d run/loki
+unzip -o -q tmp/terraform_${1}_${ARCH_NAME}_${ARCH_PROC}.zip -d run


### PR DESCRIPTION
This change will use the downloaded Terraform binaries during a `zarf p deploy`.  Notice that this still uses the local Terraform install during `zarf p create`.