### PR TITLE
ci: filter out changes to test files/dependencies

### DIFF
--- a/.github/workflows/ci-on-pull-request-dubbd-aws.yaml
+++ b/.github/workflows/ci-on-pull-request-dubbd-aws.yaml
@@ -13,6 +13,7 @@ on:
       - "**/*.svg"
       - "aws/uds-core-aws/**"
       - "aws/cloudtrail/**"
+      - "aws/**/test/**"
       - "k3d/**"
       - ".github/workflows/*k3d*.y*ml"
       - ".github/workflows/*cloudtrail*.y*ml"


### PR DESCRIPTION
Since changes to files under `test` are only for the terratests we should be safe to filter these out of the main AWS e2e workflows. The terratest workflows will still run on their own, but this will reduce load during renovate PRs.