### PR TITLE
fix: add monitoring resources to zarf.yaml

### DIFF
--- a/defense-unicorns-distro/zarf.yaml
+++ b/defense-unicorns-distro/zarf.yaml
@@ -247,6 +247,7 @@ components:
           - ../values/promtail.yaml
           - ../values/kiali.yaml
           - ../values/monitoring.yaml
+          - ../values/monitoring-resources.yaml
           - ../values/neuvector.yaml
           - ../values/tempo.yaml
   - name: dubbd-post-upgrade


### PR DESCRIPTION
Noticed during the 2.7.0 update that these were not being referenced in our zarf.yaml, so they weren't being used. I suspect this was just a mistaken removal during https://github.com/defenseunicorns/uds-package-dubbd/commit/ca10b360ee2b804c236bd9c99a579cd6978514dc