### PR TITLE
ci: add CI testing for RKE2

### DIFF
--- a/.github/workflows/ci-on-pull-request-k3d.yaml
+++ b/.github/workflows/ci-on-pull-request-k3d.yaml
@@ -17,6 +17,7 @@ on:
       - ".github/workflows/*aws*.y*ml"
       - ".github/workflows/*cloudtrail*.y*ml"
       - ".github/workflows/*uds*.y*ml"
+      - ".github/workflows/*rke2*.y*ml"
       - "**/*oscal-component.y*aml"
 
 jobs:

--- a/.github/workflows/ci-on-pull-request-rke2.yaml
+++ b/.github/workflows/ci-on-pull-request-rke2.yaml
@@ -1,4 +1,4 @@
-name: CI DUBBD AWS
+name: CI DUBBD RKE2
 
 on:
   pull_request:
@@ -11,22 +11,14 @@ on:
       - "**/*.json"
       - "**/*.png"
       - "**/*.svg"
-      - "aws/uds-core-aws/**"
-      - "aws/cloudtrail/**"
-      - "aws/**/test/**"
+      - "aws/**"
       - "k3d/**"
-      - "rke2/**"
-      # - "oscal-component.y*ml"
-      # -  aws/dubbd-aws/oscal-component.y*ml
-      # -  aws/uds-core-aws/oscal-component.y*ml
-      - "**/oscal-component.y*ml"
+      - "oscal-component.y*ml"
+      - ".github/workflows/*aws*.y*ml"
       - ".github/workflows/*k3d*.y*ml"
       - ".github/workflows/*cloudtrail*.y*ml"
       - ".github/workflows/*uds*.y*ml"
-      - ".github/workflows/*rke2*.y*ml"
-      - ".github/workflows/oscal/*oscal-component.y*ml"
-
-  workflow_call:
+      - "**/*oscal-component.y*aml"
 
 jobs:
   yaml-lint:
@@ -37,15 +29,8 @@ jobs:
         run: pip install yamllint
       - name: Lint YAML files
         run: yamllint . -c .yamllint --no-warnings
-
   test-release:
     needs: yaml-lint
     if: needs.yaml-lint.result == 'success' || needs.yaml-lint.result == 'skipped'
-    uses: ./.github/workflows/test-dubbd-aws-install.yaml
-    secrets: inherit
-
-  test-upgrade:
-    needs: yaml-lint
-    if: needs.yaml-lint.result == 'success' || needs.yaml-lint.result == 'skipped'
-    uses: ./.github/workflows/test-dubbd-aws-upgrade.yaml
+    uses: ./.github/workflows/test-dubbd-rke2-install.yaml
     secrets: inherit

--- a/.github/workflows/rke2/README.md
+++ b/.github/workflows/rke2/README.md
@@ -1,0 +1,40 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_rke2"></a> [rke2](#module\_rke2) | git::https://github.com/rancherfederal/rke2-aws-tf.git | v2.3.3 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.kubeconfig](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ami"></a> [ami](#input\_ami) | AMI to use for deployment | `string` | `"ami-03fc394d884ee7d48"` | no |
+| <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Add public IPs for nodes | `bool` | `true` | no |
+| <a name="input_controlplane_internal"></a> [controlplane\_internal](#input\_controlplane\_internal) | Make controlplane internal | `bool` | `false` | no |
+| <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | Permissions boundary for IAM Role | `string` | `"arn:aws:iam::248783118822:policy/unicorn-base-policy"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for cluster | `string` | `"dubbd-rke2-ci"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region to use for deployment | `string` | `"us-west-2"` | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets to deploy into | `list(string)` | <pre>[<br>  "subnet-0d0da65a31bcaa9dc",<br>  "subnet-0f9c052423f4ca602",<br>  "subnet-0bf47e35d4b60f338"<br>]</pre> | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to deploy into | `string` | `"vpc-0a069641d8ea3aba6"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kubeconfig_path"></a> [kubeconfig\_path](#output\_kubeconfig\_path) | n/a |

--- a/.github/workflows/rke2/README.md
+++ b/.github/workflows/rke2/README.md
@@ -1,3 +1,8 @@
+# RKE2 on AWS
+
+Terraform for deploying resources necessary for RKE2 installed on AWS with variable defaults intended for CI.
+
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -6,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 
 ## Modules
 
@@ -35,6 +40,5 @@ No requirements.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_kubeconfig_path"></a> [kubeconfig\_path](#output\_kubeconfig\_path) | n/a |
+No outputs.
+<!-- END_TF_DOCS -->

--- a/.github/workflows/rke2/main.tf
+++ b/.github/workflows/rke2/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 module "rke2" {
-  source  = "git::https://github.com/rancherfederal/rke2-aws-tf.git?ref=v2.3.3"
+  source  = "github.com/rancherfederal/rke2-aws-tf?ref=v2.3.3"
   cluster_name    = var.name
   vpc_id  = var.vpc_id
   subnets = var.subnets
@@ -97,10 +97,6 @@ resource "null_resource" "kubeconfig" {
 
   provisioner "local-exec" {
     interpreter = ["bash", "-c"]
-    command     = <<EOT
-aws s3 cp ${module.rke2.kubeconfig_path} ~/.kube/config
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.21"
-kubectl apply -f storage-class.yaml
-EOT
+    command     = "aws s3 cp ${module.rke2.kubeconfig_path} ~/.kube/config"
   }
 }

--- a/.github/workflows/rke2/main.tf
+++ b/.github/workflows/rke2/main.tf
@@ -1,0 +1,106 @@
+provider "aws" {
+  region = var.region
+}
+
+terraform {
+  backend "s3" {
+  }
+}
+
+module "rke2" {
+  source  = "git::https://github.com/rancherfederal/rke2-aws-tf.git?ref=v2.3.3"
+  cluster_name    = var.name
+  vpc_id  = var.vpc_id
+  subnets = var.subnets
+  ami     = var.ami
+  servers       = 3
+  instance_type = "m5.2xlarge"
+  tags = {
+    name = var.name
+  }
+  block_device_mappings = {
+    size = 100
+    encrypted = true
+    type = "gp3"
+  }
+  enable_ccm = true
+  iam_permissions_boundary = var.iam_permissions_boundary
+
+  rke2_version = "v1.26.6+rke2r1"
+  rke2_config = <<-EOF
+disable:
+  - rke2-ingress-nginx
+EOF
+  controlplane_internal = var.controlplane_internal
+  associate_public_ip_address = var.associate_public_ip_address
+
+  pre_userdata = <<EOF
+sudo sh -c '
+  iptables -A INPUT -p tcp -m tcp --dport 2379 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 2380 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 9345 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 6443 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p udp -m udp --dport 8472 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 10250 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 30000:32767 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 4240 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 179 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p udp -m udp --dport 4789 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 5473 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 9098 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p tcp -m tcp --dport 9099 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p udp -m udp --dport 51820 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p udp -m udp --dport 51821 -m state --state NEW -j ACCEPT
+  iptables -A INPUT -p icmp --icmp-type 8 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
+  iptables -A OUTPUT -p icmp --icmp-type 0 -m state --state ESTABLISHED,RELATED -j ACCEPT
+  iptables-save
+
+  echo "* soft nofile 13181250" >> /etc/security/limits.d/ulimits.conf
+  echo "* hard nofile 13181250" >> /etc/security/limits.d/ulimits.conf
+  echo "* soft nproc  13181250" >> /etc/security/limits.d/ulimits.conf
+  echo "* hard nproc  13181250" >> /etc/security/limits.d/ulimits.conf
+
+  sysctl -w vm.max_map_count=524288
+  echo "vm.max_map_count=524288" > /etc/sysctl.d/vm-max_map_count.conf
+
+  sysctl -w fs.nr_open=13181252
+  echo "fs.nr_open=13181252" > /etc/sysctl.d/fs-nr_open.conf
+
+  sysctl -w fs.file-max=13181250
+  echo "fs.file-max=13181250" > /etc/sysctl.d/fs-file-max.conf
+
+  echo "fs.inotify.max_user_instances=1024" > /etc/sysctl.d/fs-inotify-max_user_instances.conf
+  sysctl -w fs.inotify.max_user_instances=1024
+
+  echo "fs.inotify.max_user_watches=1048576" > /etc/sysctl.d/fs-inotify-max_user_watches.conf
+  sysctl -w fs.inotify.max_user_watches=1048576
+
+  echo "vm.overcommit_memory=1" >> /etc/sysctl.d/90-kubelet.conf
+  sysctl -w vm.overcommit_memory=1
+  echo "kernel.panic=10" >> /etc/sysctl.d/90-kubelet.conf
+  sysctl -w kernel.panic=10
+  echo "kernel.panic_on_oops=1" >> /etc/sysctl.d/90-kubelet.conf
+  sysctl -w kernel.panic_on_oops=1
+
+  sysctl -p
+
+  modprobe br_netfilter
+  modprobe xt_REDIRECT
+  modprobe xt_owner
+  modprobe xt_statistic
+'
+EOF
+}
+
+resource "null_resource" "kubeconfig" {
+  depends_on = [module.rke2]
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = <<EOT
+aws s3 cp ${module.rke2.kubeconfig_path} ~/.kube/config
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.21"
+kubectl apply -f storage-class.yaml
+EOT
+  }
+}

--- a/.github/workflows/rke2/storage-class.yaml
+++ b/.github/workflows/rke2/storage-class.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  encrypted: "true"
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer

--- a/.github/workflows/rke2/variables.tf
+++ b/.github/workflows/rke2/variables.tf
@@ -1,0 +1,48 @@
+variable "name" {
+  description = "Name for cluster"
+  type        = string
+  default = "dubbd-rke2-ci"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID to deploy into"
+  default = "vpc-0a069641d8ea3aba6"
+}
+
+variable "subnets" {
+  type = list(string)
+  description = "List of subnets to deploy into"
+  default     = ["subnet-0d0da65a31bcaa9dc","subnet-0f9c052423f4ca602","subnet-0bf47e35d4b60f338"]
+}
+
+variable "ami" {
+  type = string
+  description = "AMI to use for deployment"
+  # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230725
+  default = "ami-03fc394d884ee7d48"
+}
+
+variable "region" {
+  type = string
+  description = "Region to use for deployment"
+  default = "us-west-2"
+}
+
+variable "controlplane_internal" {
+  type = bool
+  description = "Make controlplane internal"
+  default = false # Default public for CI
+}
+
+variable "associate_public_ip_address" {
+  type = bool
+  description = "Add public IPs for nodes"
+  default = true # Default public for CI
+}
+
+variable "iam_permissions_boundary" {
+  type = string
+  description = "Permissions boundary for IAM Role"
+  default = "arn:aws:iam::248783118822:policy/unicorn-base-policy"
+}

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -28,6 +28,14 @@ jobs:
       working_dir: aws/dubbd-aws
     secrets: inherit
 
+  publish-dubbd-rke2:
+    needs: tag-new-version
+    if: ${{ needs.tag-new-version.outputs.release_created == 'true'}}
+    uses: ./.github/workflows/publish.dubbd.package.yaml
+    with:
+      working_dir: rke2
+    secrets: inherit
+
   publish-dubbd-k3d:
     needs: tag-new-version
     if: ${{ needs.tag-new-version.outputs.release_created == 'true'}}
@@ -45,6 +53,6 @@ jobs:
     secrets: inherit
 
   notify-public-uds:
-    needs: [tag-new-version, publish-dubbd-core, publish-dubbd-k3d, publish-dubbd-aws]
+    needs: [tag-new-version, publish-dubbd-core, publish-dubbd-k3d, publish-dubbd-rke2, publish-dubbd-aws]
     if: ${{ needs.tag-new-version.outputs.release_created == 'true'}}
     uses: ./.github/workflows/slack-notify-on-new-release.yaml

--- a/.github/workflows/test-dubbd-rke2-install.yaml
+++ b/.github/workflows/test-dubbd-rke2-install.yaml
@@ -1,0 +1,64 @@
+name: Test DUBBD RKE2 Package
+
+on:
+  workflow_call:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-clean-install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
+          aws-region: us-west-2
+          role-duration-seconds: 21600
+
+      - uses: ./.github/actions/create-zarf-package
+        with:
+          username: ${{ secrets.REGISTRY1_USERNAME }}
+          password: ${{ secrets.REGISTRY1_PASSWORD }}
+          working-dir: rke2
+          download-init-package: true
+          timeout-minutes: 60
+
+      - name: Create RKE2 cluster
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          terraform init -force-copy \
+            -backend-config="bucket=uds-ci-state-bucket" \
+            -backend-config="key=tfstate/ci/install/${SHA:0:7}-rke2.tfstate" \
+            -backend-config="region=us-west-2" \
+            -backend-config="dynamodb_table=uds-ci-state-dynamodb"
+          terraform plan
+          sleep 15 # time to review
+          terraform apply -auto-approve
+        working-directory: rke2
+
+      - name: Zarf init
+        run: zarf init -a amd64 --components=git-server --confirm
+
+      - name: Deploy DUBBD on RKE2 cluster
+        run: zarf package deploy zarf-package-*.tar.zst --confirm
+        working-directory: k3d
+        timeout-minutes: 60
+
+      - name: Remove DUBBD from RKE2 cluster
+        if: always()
+        run: zarf package remove zarf-package-*.tar.zst --confirm
+        working-directory: k3d
+        timeout-minutes: 60
+
+      - name: Teardown RKE2 cluster
+        if: always()
+        run: terraform destroy -auto-approve

--- a/.github/workflows/test-dubbd-rke2-install.yaml
+++ b/.github/workflows/test-dubbd-rke2-install.yaml
@@ -43,22 +43,23 @@ jobs:
           terraform plan
           sleep 15 # time to review
           terraform apply -auto-approve
-        working-directory: rke2
+        working-directory: .github/workflows/rke2
 
       - name: Zarf init
         run: zarf init -a amd64 --components=git-server --confirm
 
       - name: Deploy DUBBD on RKE2 cluster
         run: zarf package deploy zarf-package-*.tar.zst --confirm
-        working-directory: k3d
+        working-directory: rke2
         timeout-minutes: 60
 
       - name: Remove DUBBD from RKE2 cluster
         if: always()
         run: zarf package remove zarf-package-*.tar.zst --confirm
-        working-directory: k3d
+        working-directory: rke2
         timeout-minutes: 60
 
       - name: Teardown RKE2 cluster
         if: always()
         run: terraform destroy -auto-approve
+        working-directory: .github/workflows/rke2

--- a/.github/workflows/test-dubbd-rke2-install.yaml
+++ b/.github/workflows/test-dubbd-rke2-install.yaml
@@ -43,6 +43,8 @@ jobs:
           terraform plan
           sleep 15 # time to review
           terraform apply -auto-approve
+          kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.21"
+          kubectl apply -f storage-class.yaml
         working-directory: .github/workflows/rke2
 
       - name: Zarf init
@@ -57,6 +59,11 @@ jobs:
         if: always()
         run: zarf package remove zarf-package-*.tar.zst --confirm
         working-directory: rke2
+        timeout-minutes: 60
+
+      - name: Remove Zarf from RKE2 cluster
+        if: always()
+        run: zarf destroy --confirm
         timeout-minutes: 60
 
       - name: Teardown RKE2 cluster

--- a/rke2/README.md
+++ b/rke2/README.md
@@ -3,7 +3,9 @@
 This package is designed to deploy DUBBD to environments leveraging RKE2 as the Kubernetes distribution.
 
 > **Warning**
-> This package is a WIP and not configured for production deployments yet.
+> This package is a WIP and not configured for production deployments yet. Notable items:
+> - You will need to satisfy dependencies of the cluster + storage class
+> - Loki will run in a single-pod setup with PVC backed log storage
 
 ## Prerequisites
 


### PR DESCRIPTION
Adds a CI test using upstream RKE2 on AWS terraform.

"AWS-specific" pieces (storage class mainly) would migrate away from AWS specific implementations over time as we develop rook/ceph, etc.