### PR TITLE
chore: switch rke2 CI to uds-ami

### DIFF
--- a/.github/workflows/rke2/README.md
+++ b/.github/workflows/rke2/README.md
@@ -17,7 +17,8 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rke2"></a> [rke2](#module\_rke2) | git::https://github.com/rancherfederal/rke2-aws-tf.git | v2.3.3 |
+| <a name="module_agents"></a> [agents](#module\_agents) | github.com/rancherfederal/rke2-aws-tf//modules/agent-nodepool | v2.4.0 |
+| <a name="module_rke2"></a> [rke2](#module\_rke2) | github.com/rancherfederal/rke2-aws-tf | v2.4.0 |
 
 ## Resources
 
@@ -29,13 +30,14 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ami"></a> [ami](#input\_ami) | AMI to use for deployment | `string` | `"ami-03fc394d884ee7d48"` | no |
+| <a name="input_ami"></a> [ami](#input\_ami) | AMI to use for deployment, must have RKE2 pre-installed | `string` | `"ami-04953108dd85f6e49"` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Add public IPs for nodes | `bool` | `true` | no |
 | <a name="input_controlplane_internal"></a> [controlplane\_internal](#input\_controlplane\_internal) | Make controlplane internal | `bool` | `false` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | Permissions boundary for IAM Role | `string` | `"arn:aws:iam::248783118822:policy/unicorn-base-policy"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for cluster | `string` | `"dubbd-rke2-ci"` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | List of subnets to deploy into | `list(string)` | <pre>[<br>  "subnet-03bfe6a57d4778e9c",<br>  "subnet-0012c1d0524924400",<br>  "subnet-0b3c32b61de124f01"<br>]</pre> | no |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | List of subnets to deploy into | `list(string)` | <pre>[<br>  "subnet-0d0da65a31bcaa9dc",<br>  "subnet-0f9c052423f4ca602",<br>  "subnet-0bf47e35d4b60f338"<br>]</pre> | no |
 | <a name="input_region"></a> [region](#input\_region) | Region to use for deployment | `string` | `"us-west-2"` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets to deploy into | `list(string)` | <pre>[<br>  "subnet-0d0da65a31bcaa9dc",<br>  "subnet-0f9c052423f4ca602",<br>  "subnet-0bf47e35d4b60f338"<br>]</pre> | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to deploy into | `string` | `"vpc-0a069641d8ea3aba6"` | no |
 
 ## Outputs

--- a/.github/workflows/rke2/main.tf
+++ b/.github/workflows/rke2/main.tf
@@ -25,71 +25,13 @@ module "rke2" {
   }
   enable_ccm = true
   iam_permissions_boundary = var.iam_permissions_boundary
-
-  rke2_version = "v1.26.6+rke2r1"
+  download = false
   rke2_config = <<-EOF
 disable:
   - rke2-ingress-nginx
 EOF
   controlplane_internal = var.controlplane_internal
   associate_public_ip_address = var.associate_public_ip_address
-
-  pre_userdata = <<EOF
-sudo sh -c '
-  iptables -A INPUT -p tcp -m tcp --dport 2379 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 2380 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 9345 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 6443 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p udp -m udp --dport 8472 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 10250 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 30000:32767 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 4240 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 179 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p udp -m udp --dport 4789 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 5473 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 9098 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p tcp -m tcp --dport 9099 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p udp -m udp --dport 51820 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p udp -m udp --dport 51821 -m state --state NEW -j ACCEPT
-  iptables -A INPUT -p icmp --icmp-type 8 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
-  iptables -A OUTPUT -p icmp --icmp-type 0 -m state --state ESTABLISHED,RELATED -j ACCEPT
-  iptables-save
-
-  echo "* soft nofile 13181250" >> /etc/security/limits.d/ulimits.conf
-  echo "* hard nofile 13181250" >> /etc/security/limits.d/ulimits.conf
-  echo "* soft nproc  13181250" >> /etc/security/limits.d/ulimits.conf
-  echo "* hard nproc  13181250" >> /etc/security/limits.d/ulimits.conf
-
-  sysctl -w vm.max_map_count=524288
-  echo "vm.max_map_count=524288" > /etc/sysctl.d/vm-max_map_count.conf
-
-  sysctl -w fs.nr_open=13181252
-  echo "fs.nr_open=13181252" > /etc/sysctl.d/fs-nr_open.conf
-
-  sysctl -w fs.file-max=13181250
-  echo "fs.file-max=13181250" > /etc/sysctl.d/fs-file-max.conf
-
-  echo "fs.inotify.max_user_instances=1024" > /etc/sysctl.d/fs-inotify-max_user_instances.conf
-  sysctl -w fs.inotify.max_user_instances=1024
-
-  echo "fs.inotify.max_user_watches=1048576" > /etc/sysctl.d/fs-inotify-max_user_watches.conf
-  sysctl -w fs.inotify.max_user_watches=1048576
-
-  echo "vm.overcommit_memory=1" >> /etc/sysctl.d/90-kubelet.conf
-  sysctl -w vm.overcommit_memory=1
-  echo "kernel.panic=10" >> /etc/sysctl.d/90-kubelet.conf
-  sysctl -w kernel.panic=10
-  echo "kernel.panic_on_oops=1" >> /etc/sysctl.d/90-kubelet.conf
-  sysctl -w kernel.panic_on_oops=1
-
-  sysctl -p
-
-  modprobe br_netfilter
-  modprobe xt_REDIRECT
-  modprobe xt_owner
-  modprobe xt_statistic
-'
-EOF
 }
 
 resource "null_resource" "kubeconfig" {

--- a/.github/workflows/rke2/main.tf
+++ b/.github/workflows/rke2/main.tf
@@ -11,10 +11,10 @@ module "rke2" {
   source        = "github.com/rancherfederal/rke2-aws-tf?ref=v2.4.0"
   cluster_name  = var.name
   vpc_id        = var.vpc_id
-  subnets       = var.subnets
+  subnets       = var.public_subnets
   ami           = var.ami
   servers       = 1
-  instance_type = "m5.4xlarge"
+  instance_type = "m5.2xlarge"
   tags = {
     name = var.name
   }
@@ -34,6 +34,37 @@ EOF
   controlplane_internal       = var.controlplane_internal
   associate_public_ip_address = var.associate_public_ip_address
   wait_for_capacity_timeout   = "20m"
+}
+
+module "agents" {
+  source = "github.com/rancherfederal/rke2-aws-tf//modules/agent-nodepool?ref=v2.4.0"
+
+  name          = "agent"
+  vpc_id        = var.vpc_id
+  subnets       = var.private_subnets
+  ami           = var.ami
+  asg           = { min : 2, max : 2, desired : 2, termination_policies : ["Default"] }
+  spot          = false
+  instance_type = "m5.2xlarge"
+  tags = {
+    name = var.name
+  }
+  block_device_mappings = {
+    size      = 100
+    encrypted = true
+    type      = "gp3"
+  }
+  enable_ccm                = true
+  iam_permissions_boundary  = var.iam_permissions_boundary
+  download                  = false
+  rke2_config               = <<-EOF
+disable:
+  - rke2-ingress-nginx
+  - rke2-metrics-server
+EOF
+  wait_for_capacity_timeout = "20m"
+  # Required data for identifying cluster to join
+  cluster_data = module.rke2.cluster_data
 }
 
 resource "null_resource" "kubeconfig" {

--- a/.github/workflows/rke2/main.tf
+++ b/.github/workflows/rke2/main.tf
@@ -29,9 +29,11 @@ module "rke2" {
   rke2_config = <<-EOF
 disable:
   - rke2-ingress-nginx
+  - rke2-metrics-server
 EOF
   controlplane_internal = var.controlplane_internal
   associate_public_ip_address = var.associate_public_ip_address
+  wait_for_capacity_timeout = "20m"
 }
 
 resource "null_resource" "kubeconfig" {

--- a/.github/workflows/rke2/main.tf
+++ b/.github/workflows/rke2/main.tf
@@ -8,32 +8,32 @@ terraform {
 }
 
 module "rke2" {
-  source  = "github.com/rancherfederal/rke2-aws-tf?ref=v2.4.0"
-  cluster_name    = var.name
-  vpc_id  = var.vpc_id
-  subnets = var.subnets
-  ami     = var.ami
-  servers       = 3
-  instance_type = "m5.2xlarge"
+  source        = "github.com/rancherfederal/rke2-aws-tf?ref=v2.4.0"
+  cluster_name  = var.name
+  vpc_id        = var.vpc_id
+  subnets       = var.subnets
+  ami           = var.ami
+  servers       = 1
+  instance_type = "m5.4xlarge"
   tags = {
     name = var.name
   }
   block_device_mappings = {
-    size = 100
+    size      = 100
     encrypted = true
-    type = "gp3"
+    type      = "gp3"
   }
-  enable_ccm = true
-  iam_permissions_boundary = var.iam_permissions_boundary
-  download = false
-  rke2_config = <<-EOF
+  enable_ccm                  = true
+  iam_permissions_boundary    = var.iam_permissions_boundary
+  download                    = false
+  rke2_config                 = <<-EOF
 disable:
   - rke2-ingress-nginx
   - rke2-metrics-server
 EOF
-  controlplane_internal = var.controlplane_internal
+  controlplane_internal       = var.controlplane_internal
   associate_public_ip_address = var.associate_public_ip_address
-  wait_for_capacity_timeout = "20m"
+  wait_for_capacity_timeout   = "20m"
 }
 
 resource "null_resource" "kubeconfig" {

--- a/.github/workflows/rke2/variables.tf
+++ b/.github/workflows/rke2/variables.tf
@@ -1,48 +1,48 @@
 variable "name" {
   description = "Name for cluster"
   type        = string
-  default = "dubbd-rke2-ci"
+  default     = "dubbd-rke2-ci"
 }
 
 variable "vpc_id" {
   type        = string
   description = "VPC ID to deploy into"
-  default = "vpc-0a069641d8ea3aba6"
+  default     = "vpc-0a069641d8ea3aba6"
 }
 
 variable "subnets" {
-  type = list(string)
+  type        = list(string)
   description = "List of subnets to deploy into"
-  default     = ["subnet-0d0da65a31bcaa9dc","subnet-0f9c052423f4ca602","subnet-0bf47e35d4b60f338"]
+  default     = ["subnet-0d0da65a31bcaa9dc", "subnet-0f9c052423f4ca602", "subnet-0bf47e35d4b60f338"]
 }
 
 variable "ami" {
-  type = string
+  type        = string
   description = "AMI to use for deployment, must have RKE2 pre-installed"
   # https://github.com/defenseunicorns/uds-rke2-image-builder
   default = "ami-0d5808d974253f6b8"
 }
 
 variable "region" {
-  type = string
+  type        = string
   description = "Region to use for deployment"
-  default = "us-west-2"
+  default     = "us-west-2"
 }
 
 variable "controlplane_internal" {
-  type = bool
+  type        = bool
   description = "Make controlplane internal"
-  default = false # Default public for CI
+  default     = false # Default public for CI
 }
 
 variable "associate_public_ip_address" {
-  type = bool
+  type        = bool
   description = "Add public IPs for nodes"
-  default = true # Default public for CI
+  default     = true # Default public for CI
 }
 
 variable "iam_permissions_boundary" {
-  type = string
+  type        = string
   description = "Permissions boundary for IAM Role"
-  default = "arn:aws:iam::248783118822:policy/unicorn-base-policy"
+  default     = "arn:aws:iam::248783118822:policy/unicorn-base-policy"
 }

--- a/.github/workflows/rke2/variables.tf
+++ b/.github/workflows/rke2/variables.tf
@@ -20,7 +20,7 @@ variable "ami" {
   type = string
   description = "AMI to use for deployment, must have RKE2 pre-installed"
   # https://github.com/defenseunicorns/uds-rke2-image-builder
-  default = "ami-0ad84ca8c25bcbd48"
+  default = "ami-0d5808d974253f6b8"
 }
 
 variable "region" {

--- a/.github/workflows/rke2/variables.tf
+++ b/.github/workflows/rke2/variables.tf
@@ -18,9 +18,9 @@ variable "subnets" {
 
 variable "ami" {
   type = string
-  description = "AMI to use for deployment"
-  # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230725
-  default = "ami-03fc394d884ee7d48"
+  description = "AMI to use for deployment, must have RKE2 pre-installed"
+  # https://github.com/defenseunicorns/uds-rke2-image-builder
+  default = "ami-0ad84ca8c25bcbd48"
 }
 
 variable "region" {

--- a/.github/workflows/rke2/variables.tf
+++ b/.github/workflows/rke2/variables.tf
@@ -10,17 +10,23 @@ variable "vpc_id" {
   default     = "vpc-0a069641d8ea3aba6"
 }
 
-variable "subnets" {
+variable "public_subnets" {
   type        = list(string)
   description = "List of subnets to deploy into"
   default     = ["subnet-0d0da65a31bcaa9dc", "subnet-0f9c052423f4ca602", "subnet-0bf47e35d4b60f338"]
+}
+
+variable "private_subnets" {
+  type        = list(string)
+  description = "List of subnets to deploy into"
+  default     = ["subnet-03bfe6a57d4778e9c", "subnet-0012c1d0524924400", "subnet-0b3c32b61de124f01"]
 }
 
 variable "ami" {
   type        = string
   description = "AMI to use for deployment, must have RKE2 pre-installed"
   # https://github.com/defenseunicorns/uds-rke2-image-builder
-  default = "ami-0d5808d974253f6b8"
+  default = "ami-04953108dd85f6e49"
 }
 
 variable "region" {


### PR DESCRIPTION
Switches AMI for CI to the one from https://github.com/defenseunicorns/uds-rke2-image-builder

Also modifies TF to be a single server, 2 agent setup.

Closes https://github.com/defenseunicorns/uds-package-dubbd/issues/502