### PR TITLE
chore: remove dead variables from DUBBD

### DIFF
--- a/defense-unicorns-distro/zarf.yaml
+++ b/defense-unicorns-distro/zarf.yaml
@@ -11,8 +11,6 @@ metadata:
   architecture: amd64
 
 variables:
-  - name: BIGBANG_VERSION
-  - name: FLUX_VERSION
   - name: DOMAIN
     default: bigbang.dev
     prompt: false


### PR DESCRIPTION
This removes some dead variables from the DUBBD package.