### PR TITLE
fix: Propagate region variable from Zarf to Terraform

### DIFF
--- a/aws/loki/main.tf
+++ b/aws/loki/main.tf
@@ -1,4 +1,5 @@
 provider "aws" {
+  region = var.region
 }
 
 terraform {
@@ -84,14 +85,14 @@ module "generate_kms" {
 
 
 module "irsa" {
-  source                        = "github.com/defenseunicorns/terraform-aws-uds-irsa?ref=v0.0.2"
-  name                       = "${local.name}"
+  source                     = "github.com/defenseunicorns/terraform-aws-uds-irsa?ref=v0.0.2"
+  name                       = local.name
   kubernetes_service_account = var.kubernetes_service_account
   kubernetes_namespace       = var.kubernetes_namespace
   oidc_provider_arn          = local.oidc_arn
 
   role_policy_arns = tomap({
-    "loki"       = aws_iam_policy.loki_policy.arn
+    "loki" = aws_iam_policy.loki_policy.arn
   })
 
 }

--- a/aws/loki/terraform.tfvars
+++ b/aws/loki/terraform.tfvars
@@ -1,4 +1,5 @@
-name = "###ZARF_VAR_NAME###"
+region        = "###ZARF_VAR_REGION###"
+name          = "###ZARF_VAR_NAME###"
 bucket_name   = "###ZARF_VAR_NAME###-loki"
 force_destroy = "###ZARF_VAR_LOKI_FORCE_DESTROY###"
 

--- a/aws/loki/variables.tf
+++ b/aws/loki/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
 variable "name" {
   description = "Name for cluster"
   type        = string

--- a/aws/route53-policy/output.tf
+++ b/aws/route53-policy/output.tf
@@ -1,4 +1,4 @@
 output "route53_role_arn" {
   description = "ARN of the IAM Policy created for external-dns to manage records in route53."
-  value = module.irsa.role_arn
+  value       = module.irsa.role_arn
 }

--- a/aws/route53-policy/terraform.tfvars
+++ b/aws/route53-policy/terraform.tfvars
@@ -1,1 +1,2 @@
-name = "###ZARF_VAR_NAME###"
+region = "###ZARF_VAR_REGION###"
+name   = "###ZARF_VAR_NAME###"

--- a/aws/route53-policy/variables.tf
+++ b/aws/route53-policy/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
 variable "name" {
   description = "Name for cluster"
 }

--- a/aws/velero/main.tf
+++ b/aws/velero/main.tf
@@ -1,4 +1,5 @@
 provider "aws" {
+  region = var.region
 }
 
 terraform {
@@ -83,14 +84,14 @@ module "generate_kms" {
 }
 
 module "irsa" {
-  source                        = "github.com/defenseunicorns/terraform-aws-uds-irsa?ref=v0.0.2"
-  name                       = "${local.name}"
+  source                     = "github.com/defenseunicorns/terraform-aws-uds-irsa?ref=v0.0.2"
+  name                       = local.name
   kubernetes_service_account = var.kubernetes_service_account
   kubernetes_namespace       = var.kubernetes_namespace
   oidc_provider_arn          = local.oidc_arn
 
   role_policy_arns = tomap({
-    "velero"       = aws_iam_policy.velero_policy.arn
+    "velero" = aws_iam_policy.velero_policy.arn
   })
 
 }

--- a/aws/velero/terraform.tfvars
+++ b/aws/velero/terraform.tfvars
@@ -1,3 +1,4 @@
+region        = "###ZARF_VAR_REGION###"
 name          = "###ZARF_VAR_NAME###"
 bucket_name   = "###ZARF_VAR_NAME###-velero"
 force_destroy = "###ZARF_VAR_VELERO_FORCE_DESTROY###"

--- a/aws/velero/variables.tf
+++ b/aws/velero/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
 variable "name" {
   description = "Name for cluster"
   type        = string


### PR DESCRIPTION
Previously, the Terraform modules would rely on the user's default AWS region.  This will use the region passed in from Zarf to determine the AWS region for Terraform operations.

I also applied some Terraform linting, so there are a lot of whitespace changes.  You may want to hide the whitespace changes for your review.