### PR TITLE
ci: fix for eksctl to pin to a specific ami

### DIFF
--- a/.github/test-infra/eks/config.yaml
+++ b/.github/test-infra/eks/config.yaml
@@ -44,4 +44,4 @@ managedNodeGroups:
     amiFamily: AmazonLinux2
     overrideBootstrapCommand: |
       #!/bin/bash
-      /etc/eks/bootstrap.sh bigbang-aws-install --container-runtime containerd
+      /etc/eks/bootstrap.sh ###ZARF_VAR_CLUSTER_NAME### --container-runtime containerd

--- a/.github/test-infra/eks/config.yaml
+++ b/.github/test-infra/eks/config.yaml
@@ -40,7 +40,7 @@ managedNodeGroups:
       PermissionsBoundary: "###ZARF_VAR_PERMISSIONS_BOUNDARY_NAME###"
     iam:
       instanceRolePermissionsBoundary: "###ZARF_VAR_PERMISSIONS_BOUNDARY_ARN###"
-    ami: ami-018391ee17790abe8
+    ami: "###ZARF_VAR_AMI_ID###"
     amiFamily: AmazonLinux2
     overrideBootstrapCommand: |
       #!/bin/bash

--- a/.github/test-infra/eks/config.yaml
+++ b/.github/test-infra/eks/config.yaml
@@ -40,3 +40,8 @@ managedNodeGroups:
       PermissionsBoundary: "###ZARF_VAR_PERMISSIONS_BOUNDARY_NAME###"
     iam:
       instanceRolePermissionsBoundary: "###ZARF_VAR_PERMISSIONS_BOUNDARY_ARN###"
+    ami: ami-018391ee17790abe8
+    amiFamily: AmazonLinux2
+    overrideBootstrapCommand: |
+      #!/bin/bash
+      /etc/eks/bootstrap.sh bigbang-aws-install --container-runtime containerd

--- a/.github/test-infra/eks/zarf.yaml
+++ b/.github/test-infra/eks/zarf.yaml
@@ -9,6 +9,8 @@ variables:
     prompt: true
   - name: PERMISSIONS_BOUNDARY_ARN
   - name: PERMISSIONS_BOUNDARY_NAME
+  - name: AMI_ID
+    default: ami-068ab6ac1cec494e0
 
 components:
   - name: load-eksctl


### PR DESCRIPTION
issue this addresses:

using latest ami (id: ami-0b1c494fc850ef41c / name: amazon-eks-node-1.27-v20240202) as of 02/06/2024 with eksctl, when running a zarf init (any version) the zarf registry pod fails to pull the injector image with an error.

error seen:

```console
pod/zarf-docker-registry-86d779b879-gmx52                   Failed to pull image "127.0.0.1:30636/library/registry:2.8.3": rpc error: code = Unknown desc = failed to pull and unpack image "127.0.0.1:30636/library/registry:2.8.3": failed to resolve reference "127.0.0.1:30636/library/registry:2.8.3": failed to do request: Head "https://127.0.0.1:30636/v2/library/registry/manifests/2.8.3": net/http: TLS handshake timeout
```

suspecting this may be an issue with the containerd version?

```
## latest version (broken)
$ kubectl get no -owide
NAME                                           STATUS   ROLES    AGE   VERSION               INTERNAL-IP      EXTERNAL-IP      OS-IMAGE         KERNEL-VERSION                  CONTAINER-RUNTIME
ip-redacted-1.us-redacted-1.compute.internal   Ready    <none>   45m   v1.27.9-eks-5e0fdde   redacted-1   redacted-1     Amazon Linux 2   5.10.205-195.807.amzn2.x86_64   containerd://1.7.11
ip-redacted-2.us-redacted-1.compute.internal   Ready    <none>   45m   v1.27.9-eks-5e0fdde   redacted-2   redacted-2    Amazon Linux 2   5.10.205-195.807.amzn2.x86_64   containerd://1.7.11
ip-redacted-3.us-redacted-1.compute.internal    Ready    <none>   45m   v1.27.9-eks-5e0fdde   redacted-3    redacted-3   Amazon Linux 2   5.10.205-195.807.amzn2.x86_64   containerd://1.7.11

## pinned older version (works)
$ kubectl get no -owide
NAME                                           STATUS   ROLES    AGE    VERSION               INTERNAL-IP      EXTERNAL-IP     OS-IMAGE         KERNEL-VERSION                  CONTAINER-RUNTIME
ip-redacted-1.us-redacted-1.compute.internal    Ready    <none>   3m4s   v1.27.9-eks-5e0fdde   redacted-1    redacted-1   Amazon Linux 2   5.10.205-195.807.amzn2.x86_64   containerd://1.7.2
ip-redacted-2.us-redacted-1.compute.internal   Ready    <none>   3m4s   v1.27.9-eks-5e0fdde   redacted-2   redacted-2   Amazon Linux 2   5.10.205-195.807.amzn2.x86_64   containerd://1.7.2
ip-redacted-3.us-redacted-1.compute.internal   Ready    <none>   3m9s   v1.27.9-eks-5e0fdde   redacted-3   redacted-3   Amazon Linux 2   5.10.205-195.807.amzn2.x86_64   containerd://1.7.2
```